### PR TITLE
[update]解决编译时报错  SyntaxError: Non-ASCII character '\xe8' in file xxx.…

### DIFF
--- a/crawl_taobao.py
+++ b/crawl_taobao.py
@@ -1,3 +1,4 @@
+#encoding:utf-8
 from selenium import webdriver
 from selenium.webdriver.common.keys import Keys
 from selenium.common.exceptions import TimeoutException


### PR DESCRIPTION
…py on line 8, but no encoding declared; see http://www.python.org/peps/pep-0263.html for details